### PR TITLE
Fix check for presence of parameter AllowManagementOS

### DIFF
--- a/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
+++ b/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
@@ -1,4 +1,4 @@
-﻿function Get-TargetResource
+function Get-TargetResource
 {
 	[CmdletBinding()]
 	[OutputType([System.Collections.Hashtable])]
@@ -86,7 +86,7 @@ function Set-TargetResource
                 $parameters["Name"] = $Name
                 $parameters["NetAdapterName"] = $NetAdapterName
                 $parameters["MinimumBandwidthMode"] = $MinimumBandwidthMode
-                if($AllowManagementOS){$parameters["AllowManagementOS"]=$AllowManagementOS}
+                if($PSBoundParameters.ContainsKey("AllowManagementOS")){$parameters["AllowManagementOS"]=$AllowManagementOS}
                 $null = New-VMSwitch @parameters
                 Write-Verbose -Message "Switch $Name has right netadapter $NetAdapterName"
             }
@@ -119,7 +119,7 @@ function Set-TargetResource
             {
                 $parameters["NetAdapterName"] = $NetAdapterName
                 $parameters["MinimumBandwidthMode"] = $MinimumBandwidthMode
-                if($AllowManagementOS)
+                if($PSBoundParameters.ContainsKey("AllowManagementOS"))
                 {
                     $parameters["AllowManagementOS"] = $AllowManagementOS
                 }


### PR DESCRIPTION
The original test for AllowManagementOS only executed the code if AllowManagementOS was set to $true. In my case, it was necessary to prevent a network adapter to be created on the management OS.