### PR TITLE
Fix output of Get-TargetResource for cVMSwitch

### DIFF
--- a/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
+++ b/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
         }
         
         $configuration.Add('NetAdapterName', $netAdapterName)
-        $configuration.Add('NetAdapterInterfaceDescription',$switch.NetAdapterInterfaceDescriptions)
+        $configuration.Add('NetAdapterInterfaceDescription',$switch.NetAdapterInterfaceDescription)
         $configuration.Add('EmbeddedTeamingEnabled',$switch.EmbeddedTeamingEnabled)
         $configuration.Add('TeamingMode',$teamingMode)
         $configuration.Add('LoadBalancingAlgorithm',$loadBalancingAlgorithm)

--- a/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
+++ b/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
@@ -40,6 +40,8 @@ function Get-TargetResource
     if ($switch)
     {
         Write-Verbose -Message $localizedData.FoundSwitch
+        $teamingMode = 'none'
+        $loadBalancingAlgorithm = 'none'
         if ($switch.SwitchType -eq 'External')
         {
             Write-Verbose -Message $localizedData.FoundExternalSwitch
@@ -56,8 +58,8 @@ function Get-TargetResource
                             (Get-NetAdapter -InterfaceDescription $_).Name
                         }
                 )               
-                $configuration.Add('TeamingMode',$switchTeam.TeamingMode)
-                $configuration.Add('LoadBalancingAlgorithm',$switchTeam.LoadBalancingAlgorithm)
+                $teamingMode = $switchTeam.TeamingMode
+                $loadBalancingAlgorithm = $switchTeam.LoadBalancingAlgorithm
             }
             else
             {
@@ -78,6 +80,8 @@ function Get-TargetResource
         $configuration.Add('NetAdapterName', $netAdapterName)
         $configuration.Add('NetAdapterInterfaceDescription',$switch.NetAdapterInterfaceDescriptions)
         $configuration.Add('EmbeddedTeamingEnabled',$switch.EmbeddedTeamingEnabled)
+        $configuration.Add('TeamingMode',$teamingMode)
+        $configuration.Add('LoadBalancingAlgorithm',$loadBalancingAlgorithm)
         $configuration.Add('AllowManagementOS',$switch.AllowManagementOS)
         $configuration.Add('Id',$switch.Id)
         $configuration.Add('EnableIoV',$switch.IovEnabled)

--- a/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
+++ b/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
@@ -58,8 +58,8 @@ function Get-TargetResource
                             (Get-NetAdapter -InterfaceDescription $_).Name
                         }
                 )               
-                $teamingMode = $switchTeam.TeamingMode
-                $loadBalancingAlgorithm = $switchTeam.LoadBalancingAlgorithm
+                $teamingMode = "$($switchTeam.TeamingMode)"
+                $loadBalancingAlgorithm = "$($switchTeam.LoadBalancingAlgorithm)"
             }
             else
             {
@@ -86,7 +86,7 @@ function Get-TargetResource
         $configuration.Add('Id',$switch.Id)
         $configuration.Add('EnableIoV',$switch.IovEnabled)
         $configuration.Add('EnablePacketDirect',$switch.PacketDirectEnabled)
-        $configuration.Add('MinimumBandwidthMode',$switch.BandwidthReservationMode)
+        $configuration.Add('MinimumBandwidthMode',"$($switch.BandwidthReservationMode)")
         $configuration.Add('Ensure','Present')
     }
     else

--- a/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
+++ b/cHyper-V/DSCResources/cVMSwitch/cVMSwitch.psm1
@@ -50,8 +50,8 @@ function Get-TargetResource
                 Write-Verbose -Message $localizedData.FoundSetTeam
                 $switchTeam = Get-VMSwitchTeam -Name $Name
 
-                $netAdapterName = $(
-                    $switchTeam.NetAdapterInterfaceDescription | 
+                $netAdapterName = @(
+                    $switchTeam.NetAdapterInterfaceDescriptions | 
                         Foreach-Object { 
                             (Get-NetAdapter -InterfaceDescription $_).Name
                         }
@@ -61,7 +61,7 @@ function Get-TargetResource
             }
             else
             {
-                $netAdapterName = $( 
+                $netAdapterName = @( 
                     if($switch.NetAdapterInterfaceDescription)
                     {
                         (Get-NetAdapter -InterfaceDescription $switch.NetAdapterInterfaceDescription).Name
@@ -72,6 +72,7 @@ function Get-TargetResource
         else
         {
             Write-Verbose -Message ($localizedData.FoundIntORPvtSwitch -f $switch.SwitchType)
+            $netAdapterName = @()
         }
         
         $configuration.Add('NetAdapterName', $netAdapterName)


### PR DESCRIPTION
Fixes several issues in cVMSwitch Get-TargetResource:
- all properties declared in mof are always returned;
- returned properties have correct data types;
- some property mismatches are corrected.